### PR TITLE
[BACKLOG-15223] Fix the tooltip footer code not using the right data …

### DIFF
--- a/exts/detTooltip/detTooltip.js
+++ b/exts/detTooltip/detTooltip.js
@@ -607,7 +607,7 @@
 
             var app = this.model != null ? this.model.application : null;
             if(app != null && app.getDoubleClickTooltip != null) {
-                var complex = scene.datum;
+                var complex = scene.group || scene.datum;
                 if(!complex.isVirtual) {
                     try {
                         var pointFilter = this._complexToFilter(complex);


### PR DESCRIPTION
…context for querying `app.getDoubleClickTooltip(.)`.

@graimundo, @davidmsantos90, @carlosrusso, @nantunes please review.
/cc @gundisalwa